### PR TITLE
로그인 테스트 및 부가기능 개발

### DIFF
--- a/src/main/java/com/practice/studygroup/config/SecurityConfig.java
+++ b/src/main/java/com/practice/studygroup/config/SecurityConfig.java
@@ -8,15 +8,23 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.rememberme.JdbcTokenRepositoryImpl;
+import org.springframework.security.web.authentication.rememberme.PersistentTokenRepository;
+
+import javax.sql.DataSource;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final UserDetailsService userDetailsService;
+    private final DataSource dataSource;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -37,7 +45,17 @@ public class SecurityConfig {
                 .logout()
                     .logoutSuccessUrl("/")
                     .and()
+                .rememberMe().userDetailsService(userDetailsService)
+                    .tokenRepository(tokenRepository())
+                .and()
                 .build();
+    }
+
+    public PersistentTokenRepository tokenRepository() {
+        JdbcTokenRepositoryImpl jdbcTokenRepository = new JdbcTokenRepositoryImpl();
+        jdbcTokenRepository.setDataSource(dataSource);
+
+        return jdbcTokenRepository;
     }
 
     @Bean

--- a/src/main/java/com/practice/studygroup/controller/HomeController.java
+++ b/src/main/java/com/practice/studygroup/controller/HomeController.java
@@ -15,4 +15,9 @@ public class HomeController {
         model.addAttribute("account", commonUserPrincipal);
         return "index";
     }
+
+    @GetMapping("/sign-in")
+    public String signIn() {
+        return "account/sign-in";
+    }
 }

--- a/src/main/java/com/practice/studygroup/controller/UserAccountController.java
+++ b/src/main/java/com/practice/studygroup/controller/UserAccountController.java
@@ -51,11 +51,6 @@ public class UserAccountController {
         return "redirect:/";
     }
 
-    @GetMapping("/sign-in")
-    public String signIn() {
-        return "account/sign-in";
-    }
-
     @GetMapping("/check-email-token")
     public String checkEmailToken(String token, String email, Model model) {
         String checkedEmailView = "account/checked-email";

--- a/src/main/java/com/practice/studygroup/domain/PersistentLogins.java
+++ b/src/main/java/com/practice/studygroup/domain/PersistentLogins.java
@@ -1,0 +1,33 @@
+package com.practice.studygroup.domain;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Table(name = "persistent_logins")
+@Entity
+@Getter @Setter
+public class PersistentLogins {
+
+    @Id
+    @Column(length = 64)
+    private String series;
+
+    @Column(length = 64)
+    private String username;
+
+    @NotNull
+    @Column(length = 64)
+    private String token;
+
+    @NotNull
+    @Column(name = "last_used")
+    private LocalDateTime lastUsed;
+}

--- a/src/test/java/com/practice/studygroup/controller/HomeControllerTest.java
+++ b/src/test/java/com/practice/studygroup/controller/HomeControllerTest.java
@@ -1,0 +1,103 @@
+package com.practice.studygroup.controller;
+
+import com.practice.studygroup.FormDataEncoder;
+import com.practice.studygroup.config.SecurityConfig;
+import com.practice.studygroup.dto.UserAccountDto;
+import com.practice.studygroup.dto.request.SignUpForm;
+import com.practice.studygroup.dto.security.CommonUserPrincipal;
+import com.practice.studygroup.repository.UserAccountRepository;
+import com.practice.studygroup.service.UserAccountService;
+import com.practice.studygroup.validator.SignUpFormValidator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.transaction.Transactional;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 초기데이터가 생기면 @WithUserDetails를 사용해서 단위테스트로 전환
+ */
+@Transactional
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("홈 컨트롤러 - 로그인 로그아웃")
+class HomeControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired UserAccountService userAccountService;
+    @Autowired UserAccountRepository accountRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        SignUpForm signUpForm = new SignUpForm();
+        signUpForm.setNickname("kimkim11");
+        signUpForm.setEmail("kimkim11@email.com");
+        signUpForm.setPassword("12345678");
+        userAccountService.processNewUserAccount(signUpForm.toDto());
+    }
+
+    @AfterEach
+    void afterEach() {
+        accountRepository.deleteAll();
+    }
+
+    @DisplayName("[POST] - 이메일로 로그인 성공")
+    @Test
+    void login_with_email() throws Exception {
+        mockMvc.perform(post("/sign-in")
+                        .param("username", "kimkim11@email.com")
+                        .param("password", "12345678")
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"))
+                .andExpect(authenticated().withUsername("kimkim11"));
+    }
+
+    @DisplayName("[POST] - 닉네임으로 로그인 성공")
+    @Test
+    void login_with_nickname() throws Exception {
+        mockMvc.perform(post("/sign-in")
+                        .param("username", "kimkim11")
+                        .param("password", "12345678")
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"))
+                .andExpect(authenticated().withUsername("kimkim11"));
+    }
+
+    @DisplayName("[POST] - 로그인 실패")
+    @Test
+    void login_fail() throws Exception {
+        mockMvc.perform(post("/sign-in")
+                        .param("username", "111111")
+                        .param("password", "000000000")
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/sign-in?error"))
+                .andExpect(unauthenticated());
+    }
+
+    @WithMockUser
+    @DisplayName("[POST] - 로그아웃 성공")
+    @Test
+    void logout() throws Exception {
+        mockMvc.perform(post("/logout")
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/"))
+                .andExpect(unauthenticated());
+    }
+
+
+}


### PR DESCRIPTION
단위테스트로 인증시 계정생성 및  UserDetails 부여와 같은 번거로운 행위를 해야하기 때문에, 스프링 통합 테스트로 로그인테스트를 개발하였다. 
추후에 테스트계정이 디비에 존재하게 될때 단위테스트로의 전환을 고려해볼 것이다.

또한, 리멤버미 토큰 발급을 개발하였다. 세션아이디가 만료되도 토큰에 저장된 정보로 로그인을 할 수 있다. 해당토큰을 사용하기 위해
토큰 엔티티를 추가로 개발하였다.

This closes #4 