### PR TITLE
관심주제 수정 삭제 자동완성 기능

### DIFF
--- a/src/main/java/com/practice/studygroup/config/SecurityConfig.java
+++ b/src/main/java/com/practice/studygroup/config/SecurityConfig.java
@@ -23,7 +23,6 @@ import javax.sql.DataSource;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final UserDetailsService userDetailsService;
     private final DataSource dataSource;
 
     private final UserAccountRepository userAccountRepository;
@@ -47,10 +46,15 @@ public class SecurityConfig {
                 .logout()
                     .logoutSuccessUrl("/")
                     .and()
-                .rememberMe().userDetailsService(userDetailsService)
+                .rememberMe().userDetailsService(userDetailsService())
                     .tokenRepository(tokenRepository())
                 .and()
                 .build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return new CommonUserDetailService(userAccountRepository);
     }
 
 

--- a/src/main/java/com/practice/studygroup/domain/UserAccount.java
+++ b/src/main/java/com/practice/studygroup/domain/UserAccount.java
@@ -6,8 +6,10 @@ import lombok.*;
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter @Builder @AllArgsConstructor
@@ -59,7 +61,7 @@ public class UserAccount {
 
     private boolean studyUpdateResultByWeb;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "userAccount", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "userAccount", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<UserAccountTag> tags = new HashSet<>();
 
     protected UserAccount() {
@@ -117,4 +119,7 @@ public class UserAccount {
     public void setTag(UserAccountTag userAccountTag) {
         this.tags.add(userAccountTag);
     }
+
+
+
 }

--- a/src/main/java/com/practice/studygroup/repository/TagRepository.java
+++ b/src/main/java/com/practice/studygroup/repository/TagRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     Optional<Tag> findByTitle(String title);
+
+    boolean deleteByTitle(String tagTitle);
 }

--- a/src/main/java/com/practice/studygroup/security/service/CommonUserDetailService.java
+++ b/src/main/java/com/practice/studygroup/security/service/CommonUserDetailService.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
 @Transactional
 @RequiredArgsConstructor
 public class CommonUserDetailService implements UserDetailsService {

--- a/src/main/java/com/practice/studygroup/service/TagService.java
+++ b/src/main/java/com/practice/studygroup/service/TagService.java
@@ -1,11 +1,19 @@
 package com.practice.studygroup.service;
 
 import com.practice.studygroup.domain.Tag;
+import com.practice.studygroup.domain.UserAccount;
+import com.practice.studygroup.domain.UserAccountTag;
 import com.practice.studygroup.dto.TagDto;
 import com.practice.studygroup.repository.TagRepository;
+import com.practice.studygroup.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -14,9 +22,18 @@ public class TagService {
 
     private final TagRepository tagRepository;
 
+    private final UserAccountRepository userAccountRepository;
+
     @Transactional
     public TagDto findOrCreateNew(String tagTitle) {
         return TagDto.from(tagRepository.findByTitle(tagTitle)
                 .orElseGet(() -> tagRepository.save(Tag.of(tagTitle))));
+    }
+
+
+    public List<String> getAllTags() {
+        return tagRepository.findAll().stream()
+                .map(Tag::getTitle)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/practice/studygroup/service/UserAccountService.java
+++ b/src/main/java/com/practice/studygroup/service/UserAccountService.java
@@ -22,6 +22,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -35,6 +37,8 @@ public class UserAccountService {
     private final TagRepository tagRepository;
     private final JavaMailSender javaMailSender;
     private final PasswordEncoder passwordEncoder;
+    private final EntityManager em;
+
 
     @Transactional
     public void addTag(String nickname, TagDto tagDto) {
@@ -156,5 +160,21 @@ public class UserAccountService {
                 .stream()
                 .map(e -> e.getTag())
                 .collect(Collectors.toSet());
+    }
+
+    @Transactional
+    public boolean removeTag(String nickname, String tagTitle) {
+        UserAccount userAccount = userAccountRepository.findByNickname(nickname);
+        Optional<UserAccountTag> userAccountTag = userAccount.getTags()
+                .stream()
+                .filter(tag -> tag
+                        .getTag()
+                        .getTitle()
+                        .equals(tagTitle))
+                .findFirst();
+
+        userAccountTag.ifPresent(tag -> userAccount.getTags().remove(tag));
+
+        return userAccountTag.isPresent();
     }
 }

--- a/src/main/resources/templates/settings/tags.html
+++ b/src/main/resources/templates/settings/tags.html
@@ -51,6 +51,7 @@
             참여하고 싶은 스터디 주제를 입력해 주세요. 해당 주제의 스터디가 생기면 알림을 받을 수 있습니다. 태그를 입력하고 콤마(,)
             또는 엔터를 입력하세요.
           </div>
+          <div id="whitelist" th:text="${whitelist}" hidden></div>
           <input id="tags" type="text" name="tags" th:value="${#strings.listJoin(tags,',')}"
                  class="tagify-outside" aria-describedby="tagHelp" placeholder="태그를 입력해주세요."/>
         </div>
@@ -92,6 +93,7 @@
 
         var tagify = new Tagify(tagInput, {
             pattern: /^.{0,20}$/,
+            whitelist: JSON.parse(document.querySelector("#whitelist").textContent),
             dropdown: {
                 enabled: 1, // suggest tags after a single character input
             } // map tags

--- a/src/test/java/com/practice/studygroup/WithAccount.java
+++ b/src/test/java/com/practice/studygroup/WithAccount.java
@@ -6,7 +6,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
-@WithSecurityContext(factory = WithAccountSecurityContextFacotry.class)
+@WithSecurityContext(factory = WithAccountSecurityContextFactory.class)
 public @interface WithAccount {
 
     String value();

--- a/src/test/java/com/practice/studygroup/WithAccountSecurityContextFactory.java
+++ b/src/test/java/com/practice/studygroup/WithAccountSecurityContextFactory.java
@@ -9,13 +9,19 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import org.springframework.transaction.annotation.Transactional;
 
-public class WithAccountSecurityContextFacotry implements WithSecurityContextFactory<WithAccount> {
+import javax.persistence.EntityManager;
+
+
+public class WithAccountSecurityContextFactory implements WithSecurityContextFactory<WithAccount> {
 
     @Autowired
     private UserDetailsService userDetailsService;
     @Autowired
     private UserAccountService userAccountService;
+    @Autowired
+    private EntityManager em;
 
     @Override
     public SecurityContext createSecurityContext(WithAccount withAccount) {
@@ -26,6 +32,9 @@ public class WithAccountSecurityContextFacotry implements WithSecurityContextFac
         signUpForm.setEmail(nickname + "@email.com");
         signUpForm.setPassword("12345678");
         userAccountService.processNewUserAccount(signUpForm.toDto());
+
+        em.flush();
+        em.clear();
 
         UserDetails principal = userDetailsService.loadUserByUsername(nickname);
         Authentication authentication = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());

--- a/src/test/java/com/practice/studygroup/controller/UserAccountControllerTest.java
+++ b/src/test/java/com/practice/studygroup/controller/UserAccountControllerTest.java
@@ -116,7 +116,7 @@ class UserAccountControllerTest {
         String email = "kkkkk@naver.com";
         String token = "This Is Plain Text";
         UserAccountDto dto = UserAccountDto.builder().email(email).build();
-        given(userAccountService.isCorrectTokenAndSignUp(email, token)).willReturn(false);
+        given(userAccountService.isCorrectTokenAndVerifyEmail(email, token)).willReturn(false);
         given(userAccountService.loginAfterModifyInfo(email)).willReturn(CommonUserPrincipal.from(dto));
 
         // When
@@ -129,7 +129,7 @@ class UserAccountControllerTest {
                 .andExpect(unauthenticated());
 
         // Then
-        then(userAccountService).should().isCorrectTokenAndSignUp(email, token);
+        then(userAccountService).should().isCorrectTokenAndVerifyEmail(email, token);
 
     }
 
@@ -146,7 +146,7 @@ class UserAccountControllerTest {
                 .email(email)
                 .nickname(nick)
                 .build();
-        given(userAccountService.isCorrectTokenAndSignUp(email, token)).willReturn(true);
+        given(userAccountService.isCorrectTokenAndVerifyEmail(email, token)).willReturn(true);
         given(userAccountService.loginAfterModifyInfo(email)).willReturn(CommonUserPrincipal.from(dto));
 
         // When
@@ -160,7 +160,7 @@ class UserAccountControllerTest {
                 .andExpect(authenticated().withUsername(nick));
 
         // Then
-        then(userAccountService).should().isCorrectTokenAndSignUp(email, token);
+        then(userAccountService).should().isCorrectTokenAndVerifyEmail(email, token);
         then(userAccountService).should().loginAfterModifyInfo(email);
     }
 

--- a/src/test/java/com/practice/studygroup/service/UserAccountServiceTest.java
+++ b/src/test/java/com/practice/studygroup/service/UserAccountServiceTest.java
@@ -13,6 +13,8 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
@@ -36,6 +38,7 @@ class UserAccountServiceTest {
         UserAccountDto dto = createUserAccountDto();
         UserAccount entity = dto.toEntity(passwordEncoder);
         given(userAccountRepository.save(entity)).willReturn(entity);
+        given(userAccountRepository.findByEmail(dto.getEmail())).willReturn(Optional.of(entity));
 
         // When
         sut.processNewUserAccount(dto);
@@ -43,6 +46,8 @@ class UserAccountServiceTest {
         // Then
         assertThat(dto.getPassword()).isNotSameAs(entity.getPassword());
         then(userAccountRepository).should().save(entity);
+        then(userAccountRepository).should().findByEmail(dto.getEmail());
+
     }
 
     private UserAccountDto createUserAccountDto() {


### PR DESCRIPTION
태그 수정 삭제 기능을 개발하였다.
태그 삭제시 hard delete로, orphanRemoval(연관관계 끊키면 자식객체가 삭제됨, 컬렉션에서 삭제가능) 을 이용하여 제거하였다.
하지만 어플리케이션에서는 잘 동작하였으나 테스트에서는 잘 동작하지 않았다.
추후 보완이 필요하다 
This closes #21 